### PR TITLE
PyPi Standalone

### DIFF
--- a/PY_LGPIO/setup.py
+++ b/PY_LGPIO/setup.py
@@ -5,11 +5,16 @@ setup.py file for SWIG lgpio
 """
 
 from setuptools import setup, Extension
+import glob
 
 with open('README.md') as f:
     long_description = f.read()
 
-lgpio_module = Extension('_lgpio', sources=['lgpio_wrap.c',], libraries=['lgpio',],)
+sources = glob.glob("../lg*.c")
+sources.append('../rgpiod.c')
+sources.append('lgpio_wrap.c')
+
+lgpio_module = Extension('_lgpio', sources=sources, libraries=['rt', 'dl'], extra_compile_args=['-I../', '-pthread'])
 
 setup (name = 'lgpio',
        version = '0.2.2.0',

--- a/PY_LGPIO/setup.py
+++ b/PY_LGPIO/setup.py
@@ -12,7 +12,8 @@ with open('README.md') as f:
 
 sources = glob.glob("../lg*.c")
 sources.append('../rgpiod.c')
-sources.append('lgpio_wrap.c')
+sources.append('lgpio.i')
+
 
 lgpio_module = Extension('_lgpio', sources=sources, libraries=['rt', 'dl'], extra_compile_args=['-I../', '-pthread'])
 


### PR DESCRIPTION
These changes build a PY_LGPIO library that can be installed without any dependence on system libraries.

It does this by building the entire lg library into the Python C extension, and additionally lets `setup.py` handle the `swig` step (compiling the interface file into a C wrapper) so it does not need to be done manually.

For this to be optimal as a source distribution, we'd probably want to include `lgpio_wrap.c` in the distribution - via MANIFEST.in - and include some logic to only add `lgpio.i` as a source file if `lpgio_wrap.c` is missing. This would remove the dependency upon swig for users.

We should probably also convert this to some more modern packaging standard, though that is a secondary concern to just getting what we have working.

Edit: notable quirk for supplying a source distribution is that it's difficult to include the *parent* directory in the Python package. It would make more sense if the Python library files were *another* git repository which included lg as a submodule. That would also let packaging be a little more agile without spamming the base repo with Python-specific commits.